### PR TITLE
Hide reset cross icon in the search box when there is no value

### DIFF
--- a/src/components/SearchBar/SearchBar.tsx
+++ b/src/components/SearchBar/SearchBar.tsx
@@ -82,12 +82,16 @@ export class SearchBarComponent extends React.Component<ISearchBarProps, ISearch
         <span className={searchbarHighlightStyle}>
           {str.replace(/ /g, "\u00a0")}
         </span>
-        <i
-          className={searchBarClearStyle}
-          onClick={this.onClear}
-        >
-          <Cross />
-        </i>
+        {
+          str.trim() && (
+            <i
+              className={searchBarClearStyle}
+              onClick={this.onClear}
+            >
+              <Cross />
+            </i>
+          )
+        }
       </div>
     );
   }


### PR DESCRIPTION
This will hide the reset icon for the following cases,
- when there is no value
- when search bar is empty
- when search bar contains only spaces